### PR TITLE
GHUB-295 Add extra workflow job for keeping the repo "alive".

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,11 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           RENOVATE_PR_HOURLY_LIMIT: ${{ inputs.hourly_limit }}
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
Uses https://github.com/liskin/gh-workflow-keepalive which automatically re-enables the workflow on schedule event via API.